### PR TITLE
feat: Add ability to skip already-built libraries

### DIFF
--- a/ALCF/Aurora/torch/install-pt2p8.sh
+++ b/ALCF/Aurora/torch/install-pt2p8.sh
@@ -241,6 +241,36 @@ prepare_repo_in_build_dir() {
     cd - || return 1
 }
 
+check_if_already_built() {
+    # Check if the wheel file already exists in the build directory
+    if [[ "$#" -ne 1 ]]; then
+        echo "Usage: $0 <build_dir>"
+        return 1
+    fi
+    local bdir; bdir="$(realpath "$1")"
+    if [[ -d "${bdir}/dist" ]]; then
+        whls=$(ls "${bdir}/dist"/*.whl 2>/dev/null)
+        if [[ -n "${whls}" ]]; then
+            echo "Found existing wheels in ${bdir}/dist:"
+            for whl in ${whls}; do
+                echo "  - ${whl}"
+            done
+            echo "Skipping build. If you want to rebuild, please delete the existing wheels."
+            return 0
+        else
+            echo "No existing wheels found in ${bdir}/dist. Proceeding with build."
+        fi
+    fi
+    # if [[ -n "${whl}" ]]; then
+    #     echo "Found existing wheel: ${whl}"
+    #     echo "Skipping build. If you want to rebuild, please delete the existing wheel."
+    #     return 0
+    # else
+    #     echo "No existing wheel found in ${bdir}. Proceeding with build."
+    #     return 1
+    # fi
+}
+
 # Function to build PyTorch from source in the specified build directory.
 # Usage: build_pytorch <build_dir>
 # Where <build_dir> is the directory where PyTorch will be built.
@@ -260,12 +290,21 @@ build_pytorch() {
         echo "Where <build_dir> is the directory where PyTorch will be built."
         return 1
     fi
+    # if python3 -c 'import torch' &>/dev/null; then
+    #     echo "PyTorch is already installed. Continuing with installation!."
+    #     return 0
+    # fi
     build_dir="$(realpath "$1")"
     pt_url="https://github.com/pytorch/pytorch"
     prepare_repo_in_build_dir "${build_dir}" "${pt_url}" || {
         echo "Failed to prepare PyTorch repository."
         return 1
     }
+
+    if check_if_already_built "${build_dir}/pytorch"; then
+        echo "PyTorch wheel already exists. Skipping build."
+        return 0
+    fi
 
     echo "Navigating into ${build_dir}/pytorch/"
     cd "${build_dir}/pytorch" || return 1
@@ -341,6 +380,12 @@ build_ipex() {
         echo "Failed to prepare Intel Extension for PyTorch repository."
         return 1
     }
+    # Check if the wheel file already exists in the build directory
+    if check_if_already_built "${build_dir}/intel-extension-for-pytorch"; then
+        echo "Intel Extension for PyTorch wheel already exists. Skipping build."
+        return 0
+    fi
+
     cd "${build_dir}/intel-extension-for-pytorch" || return 1
 
     echo "Checking out xpu-main branch..."
@@ -375,6 +420,12 @@ build_torch_ccl() {
         return 1
     }
 
+    # Check if the wheel file already exists in the build directory
+    if check_if_already_built "${build_dir}/torch-ccl"; then
+        echo "torch-ccl wheel already exists. Skipping build."
+        return 0
+    fi
+
     cd "${build_dir}/torch-ccl" || return 1
 
     echo "Checking out specific commit c27ded5..."
@@ -404,6 +455,11 @@ build_mpi4py() {
         echo "Failed to prepare mpi4py repository."
         return 1
     }
+    # Check if the wheel file already exists in the build directory
+    if check_if_already_built "${build_dir}/mpi4py"; then
+        echo "mpi4py wheel already exists. Skipping build."
+        return 0
+    fi
     cd "${build_dir}/mpi4py" || return 1
     echo "Building mpi4py..."
     CC=mpicc CXX=mpicxx python3 setup.py bdist_wheel | tee "mpi4py-build-whl-$(tstamp).log"
@@ -428,6 +484,12 @@ build_h5py() {
         echo "Failed to prepare h5py repository."
         return 1
     }
+
+    # Check if the wheel file already exists in the build directory
+    if check_if_already_built "${build_dir}/h5py"; then
+        echo "h5py wheel already exists. Skipping build."
+        return 0
+    fi
 
     echo "Installing h5py..."
     module load hdf5
@@ -455,6 +517,11 @@ build_torch_ao() {
         echo "Failed to prepare torch/ao repository."
         return 1
     }
+    # Check if the wheel file already exists in the build directory
+    if check_if_already_built "${build_dir}/ao"; then
+        echo "torch/ao wheel already exists. Skipping build."
+        return 0
+    fi
 
     echo "Building torch/ao..."
     cd "${build_dir}/ao" || return 1
@@ -477,6 +544,11 @@ build_torchtune() {
         echo "Failed to prepare TorchTune repository."
         return 1
     }
+    # Check if the wheel file already exists in the build directory
+    if check_if_already_built "${build_dir}/torchtune"; then
+        echo "TorchTune wheel already exists. Skipping build."
+        return 0
+    fi
 
     echo "Installing TorchTune in editable mode..."
     cd "${build_dir}/torchtune" || return 1


### PR DESCRIPTION
## Copilot Summary

This pull request adds functionality to check for existing wheel files in the build directories before proceeding with the build process. This ensures that redundant builds are avoided, improving efficiency and reducing unnecessary computations.

### Added functionality to skip redundant builds:
* **New function `check_if_already_built`:** Introduced a utility function to check if wheel files already exist in a specified build directory. If wheels are found, the function skips the build process and provides instructions for rebuilding. (`ALCF/Aurora/torch/install-pt2p8.sh`, [ALCF/Aurora/torch/install-pt2p8.shR244-R273](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R244-R273))
* **Integration with build functions:**
  - Updated `build_pytorch` to use `check_if_already_built` for detecting existing PyTorch wheels before building. (`ALCF/Aurora/torch/install-pt2p8.sh`, [ALCF/Aurora/torch/install-pt2p8.shR293-R308](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R293-R308))
  - Applied the same check in `build_ipex`, `build_torch_ccl`, `build_mpi4py`, `build_h5py`, `build_torch_ao`, and `build_torchtune` functions to skip builds if wheels are already present for respective components. (`ALCF/Aurora/torch/install-pt2p8.sh`, [[1]](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R383-R388) [[2]](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R423-R428) [[3]](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R458-R462) [[4]](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R488-R493) [[5]](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R520-R524) [[6]](diffhunk://#diff-5dd321163a2a6700fcf8fec11eb273acd5d0e369c4cd186dd6a935b37d1e60f2R547-R551)